### PR TITLE
Added support for cmd input for "was_generated_by" field in functional annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Commands:
 
 ### Test the package
 
-The test_data directory contains two example gff files and the corresponding JSON outputs.
+The test_data directory contains two example gff files and the corresponding JSON outputs. Note that the string `nmdc:4ce9a799923b238585fc952135e5a0f5` is an example activity id.
    
 ```sh
-MetaG_annotation$  nmdc gff2json -of simple_feature.json -oa simple_func.json src/nmdc/test_data/MetaG_annotation/simple_example.gff
+
+MetaG_annotation$ nmdc gff2json -of simple_feature.json -oa simple_func.json -ai nmdc:4ce9a799923b238585fc952135e5a0f5 simple_example.gff 
 ```
 
 This command will generate two json files: `simple_feature.json` has the genome feature and `simple_func.json` has the functional annotation.
@@ -76,36 +77,43 @@ Ga0185794_41	GeneMark.hmm-2 v1.05	CDS	48	1037	56.13	+	0	ID=Ga0185794_41_48_1037;
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "5-methylthioadenosine/S-adenosylhomocysteine deaminase",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "CATH:3.20.20.140",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "EGGNOG:COG0402",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "KEGG.ORTHOLOGY:K12960",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "EC:3.5.4.28",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "PFAM:PF01979",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "SUPFAM:51338",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     }
   ]

--- a/src/nmdc/scripts/__main__.py
+++ b/src/nmdc/scripts/__main__.py
@@ -25,12 +25,16 @@ def nmdccli():
               help='output file name for functioanl annotation json',
               required=True,
               type=click.File(mode='w'))
-def gff2json(gff, of, oa):
+@click.option('-ai',
+              help='Activity index',
+              required=True,
+              type=str)
+def gff2json(gff, of, oa, ai):
     """
     Convert GFF3 to NMDC JSON format.
     """
     INDENT = 2
-    converter = NMDCGFFLoader(gff)
+    converter = NMDCGFFLoader(gff, ai)
     jobj = converter.model
     features = []
     annotations = []
@@ -39,20 +43,6 @@ def gff2json(gff, of, oa):
             entry = jobj[record][feature]
             features.append(entry['feature_set'])
             annotations.extend(list(entry['functional_annotation_set'].values()))
-            #of.write(json.dumps(gf, indent=INDENT))
-            # num_annotations = len(fa)
-            # oa.write('[\n')
-            # for i, annotation in enumerate(fa.keys(), start=1):
-            #     oa.write(json.dumps(fa[annotation], indent=INDENT))
-            #     if i < num_annotations:
-            #         oa.write(',')
-            # oa.write(']\n')
-        # for feature in jobj[record].keys():
-            # entry = jobj[record][feature]
-            # gf = entry['genome_feature']
-            # fa = entry['functional_annotation']
-            # of.write(json.dumps(gf, indent=INDENT))
-            # oa.write(json.dumps(fa,  indent=INDENT))
     of.write(json.dumps({'feature_set': features}, indent=INDENT))
     oa.write(json.dumps({'functional_annotation_set': annotations}, indent=INDENT))
 

--- a/src/nmdc/test_data/MetaG_annotation/simple_func.json
+++ b/src/nmdc/test_data/MetaG_annotation/simple_func.json
@@ -3,36 +3,43 @@
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "5-methylthioadenosine/S-adenosylhomocysteine deaminase",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "CATH:3.20.20.140",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "EGGNOG:COG0402",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "KEGG.ORTHOLOGY:K12960",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "EC:3.5.4.28",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "PFAM:PF01979",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     },
     {
       "subject": "NMDC:Ga0185794_41_48_1037",
       "has_function": "SUPFAM:51338",
+      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
       "type": "NMDC:FunctionalAnnotation"
     }
   ]

--- a/src/nmdc/tests/test_gff2json.py
+++ b/src/nmdc/tests/test_gff2json.py
@@ -10,11 +10,13 @@ class testGFF2JSON(unittest.TestCase):
         Test annotations beyond GenomeFeature.
         """
         gff_str = 'Ga0185794_41\tGeneMark.hmm-2 v1.05\tCDS\t48\t1037\t56.13\t+\t0\tID=Ga0185794_41_48_1037;translation_table=11;start_type=ATG;product=5-methylthioadenosine/S-adenosylhomocysteine deaminase;product_source=KO:K12960;cath_funfam=3.20.20.140;cog=COG0402;ko=KO:K12960;ec_number=EC:3.5.4.28,EC:3.5.4.31;pfam=PF01979;superfamily=51338,51556'
+        ai = 'nmdc:4ce9a799923b238585fc952135e5a0f5'
         print(f'Test GenomeFeature ...\n\nInput:\n\t{gff_str}\n')
+
         with io.StringIO() as fh:
             fh.write(gff_str)
             fh.seek(0)
-            parser = NMDCGFFLoader(fh)
+            parser = NMDCGFFLoader(fh, ai)
             jst = parser.get_json()
             print('Output in JSON:')
             print(jst)
@@ -29,7 +31,7 @@ class testGFF2JSON(unittest.TestCase):
             self.assertEqual(gf['type'], 'SO:0000316')
             self.assertEqual(af['cog']['has_function'], "EGGNOG:COG0402")
             self.assertEqual(af['ko']['has_function'],
-                             "KO:K12960")
+                             "KEGG.ORTHOLOGY:K12960")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 $nmdc gff2json -of simple_feature.json -oa simple_func.json -ai nmdc:4ce9a799923b238585fc952135e5a0f5 simple_example.gff $ cat simple_func.json 
{
  "functional_annotation_set": [
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "5-methylthioadenosine/S-adenosylhomocysteine deaminase",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "CATH:3.20.20.140",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "EGGNOG:COG0402",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "KEGG.ORTHOLOGY:K12960",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "EC:3.5.4.28",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "PFAM:PF01979",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    },
    {
      "subject": "NMDC:Ga0185794_41_48_1037",
      "has_function": "SUPFAM:51338",
      "was_generated_by": "nmdc:4ce9a799923b238585fc952135e5a0f5",
      "type": "NMDC:FunctionalAnnotation"
    }
  ]
}