### PR TITLE
allow adding to pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ class PostInstallCommand(install):
 
 
 setup(
-    name='pynmdc',
+    name='nmdc',
     version=VERSION,
     description="Study-level NGS bioinformatics toolbox",
     long_description=README,
+    long_description_content_type="text/markdown",
     classifiers=[
         # http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Changes to setup.py to render description content, and to name package as "nmdc" (already know it's a python package).

Already pushed <https://pypi.org/project/nmdc/> and added @hubin-keio as an owner. This PR makes the repo consistent with the pushed package.